### PR TITLE
Update warning bits info

### DIFF
--- a/src/tryte.rs
+++ b/src/tryte.rs
@@ -29,7 +29,7 @@ use crate::concepts::DigitOperate;
 ///
 /// Because arithmetic operations are performed in with 64 bits integers, `SIZE` cannot be > 40.
 ///
-/// > **40 trits ~= 63,398 bits**
+/// > **40 trits ~= 63.398 bits**
 /// >
 /// > `-6 078 832 729 528 464 400` to `6 078 832 729 528 464 400`
 ///


### PR DESCRIPTION
## Summary
- fix bit notation in `src/tryte.rs` warning comment

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6846e4445dfc832fa5594e65b6be9c5c