### PR TITLE
Add FromStr parsing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ fn test() {
 
     let ternary = Ternary::parse("+--");
     assert_eq!(ternary.to_dec(), 5);
+
+    let ternary = "+-0".parse::<Ternary>().unwrap();
+    assert_eq!(ternary.to_string(), "+-0");
 }
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@ use crate::concepts::DigitOperate;
 #[cfg(feature = "ternary-string")]
 use core::{
     fmt::{Display, Formatter},
+    str::FromStr,
 };
 
 /// Provides helper functions for formatting integers in a given radix.
@@ -307,7 +308,7 @@ impl Ternary {
         let mut carry = 0u8;
         let mut repr = Ternary::new(vec![]);
         for digit in str.chars().rev() {
-            let digit = <u8 as core::str::FromStr>::from_str(&digit.to_string()).unwrap() + carry;
+            let digit = <u8 as FromStr>::from_str(&digit.to_string()).unwrap() + carry;
             if digit < 2 {
                 repr.digits.push(Digit::from_i8(digit as i8));
                 carry = 0;
@@ -612,7 +613,7 @@ impl Display for Ternary {
 }
 
 #[cfg(feature = "ternary-string")]
-impl core::str::FromStr for Ternary {
+impl FromStr for Ternary {
     type Err = core::convert::Infallible;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -636,8 +637,6 @@ mod tryte;
 
 #[cfg(feature = "tryte")]
 pub use crate::tryte::Tryte;
-
-pub use core::str::FromStr;
 
 #[cfg(test)]
 #[cfg(feature = "ternary-string")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@ use crate::concepts::DigitOperate;
 use core::{
     fmt::{Display, Formatter},
     str::FromStr,
+    error::Error,
 };
 
 #[cfg(feature = "ternary-string")]
@@ -82,8 +83,8 @@ impl Display for ParseTernaryError {
     }
 }
 
-#[cfg(all(feature = "ternary-string", feature = "std"))]
-impl std::error::Error for ParseTernaryError {}
+#[cfg(feature = "ternary-string")]
+impl Error for ParseTernaryError {}
 
 /// Provides helper functions for formatting integers in a given radix.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,6 @@ use crate::concepts::DigitOperate;
 #[cfg(feature = "ternary-string")]
 use core::{
     fmt::{Display, Formatter},
-    str::FromStr,
 };
 
 /// Provides helper functions for formatting integers in a given radix.
@@ -144,6 +143,8 @@ pub const fn trit(from: char) -> Digit {
 /// use balanced_ternary::{ter, Ternary};
 ///
 /// let ternary = ter("+-0+");
+/// assert_eq!(ternary.to_string(), "+-0+");
+/// let ternary = "+-0+".parse::<Ternary>().unwrap();
 /// assert_eq!(ternary.to_string(), "+-0+");
 /// ```
 #[cfg(feature = "ternary-string")]
@@ -269,6 +270,14 @@ impl Ternary {
     /// Parses a string representation of a balanced ternary number into a `Ternary` object.
     ///
     /// Each character in the string must be one of `+`, `0`, or `-`.
+    ///
+    /// # Example
+    /// ```
+    /// use balanced_ternary::Ternary;
+    ///
+    /// let ternary = "+-0".parse::<Ternary>().unwrap();
+    /// assert_eq!(ternary.to_string(), "+-0");
+    /// ```
     pub fn parse(str: &str) -> Self {
         let mut repr = Ternary::new(vec![]);
         for c in str.chars() {
@@ -298,7 +307,7 @@ impl Ternary {
         let mut carry = 0u8;
         let mut repr = Ternary::new(vec![]);
         for digit in str.chars().rev() {
-            let digit = u8::from_str(&digit.to_string()).unwrap() + carry;
+            let digit = <u8 as core::str::FromStr>::from_str(&digit.to_string()).unwrap() + carry;
             if digit < 2 {
                 repr.digits.push(Digit::from_i8(digit as i8));
                 carry = 0;
@@ -603,6 +612,15 @@ impl Display for Ternary {
 }
 
 #[cfg(feature = "ternary-string")]
+impl core::str::FromStr for Ternary {
+    type Err = core::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Ternary::parse(s))
+    }
+}
+
+#[cfg(feature = "ternary-string")]
 mod operations;
 
 mod conversions;
@@ -618,6 +636,8 @@ mod tryte;
 
 #[cfg(feature = "tryte")]
 pub use crate::tryte::Tryte;
+
+pub use core::str::FromStr;
 
 #[cfg(test)]
 #[cfg(feature = "ternary-string")]
@@ -741,4 +761,20 @@ fn test_operations() {
     test_ternary_eq(short.each(Digit::absolute_negative), "-0-");
 
     test_binary_op(&long, Digit::mul, &other, "+0-000-0+");
+}
+
+#[cfg(test)]
+#[cfg(feature = "ternary-string")]
+#[test]
+fn test_from_str() {
+    use core::str::FromStr;
+
+    let ternary = Ternary::from_str("+-0").unwrap();
+    assert_eq!(ternary.to_string(), "+-0");
+
+    #[cfg(feature = "tryte")]
+    {
+        let tryte = <crate::Tryte>::from_str("+-0").unwrap();
+        assert_eq!(tryte.to_string(), "000+-0");
+    }
 }

--- a/src/tryte.rs
+++ b/src/tryte.rs
@@ -314,10 +314,10 @@ impl<const SIZE: usize> From<Tryte<SIZE>> for i64 {
 }
 
 impl<const SIZE: usize> FromStr for Tryte<SIZE> {
-    type Err = core::convert::Infallible;
+    type Err = crate::ParseTernaryError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Tryte::from_ternary(&Ternary::parse(s)))
+        Ok(Tryte::from_ternary(&Ternary::from_str(s)?))
     }
 }
 
@@ -347,4 +347,6 @@ pub fn test_tryte_from_str() {
 
     let tryte = Tryte::<6>::from_str("+-0").unwrap();
     assert_eq!(tryte.to_string(), "000+-0");
+
+    assert!(Tryte::<6>::from_str("+-x").is_err());
 }

--- a/src/tryte.rs
+++ b/src/tryte.rs
@@ -312,6 +312,14 @@ impl<const SIZE: usize> From<Tryte<SIZE>> for i64 {
     }
 }
 
+impl<const SIZE: usize> core::str::FromStr for Tryte<SIZE> {
+    type Err = core::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Tryte::from_ternary(&Ternary::parse(s)))
+    }
+}
+
 #[cfg(test)]
 #[test]
 pub fn test_tryte() {
@@ -329,4 +337,13 @@ pub fn test_tryte() {
     assert_eq!(Tryte::<6>::MIN.to_i64(), -364);
     assert_eq!(Tryte::<6>::ZERO.to_string(), "000000");
     assert_eq!(Tryte::<6>::ZERO.to_i64(), 0);
+}
+
+#[cfg(test)]
+#[test]
+pub fn test_tryte_from_str() {
+    use core::str::FromStr;
+
+    let tryte = Tryte::<6>::from_str("+-0").unwrap();
+    assert_eq!(tryte.to_string(), "000+-0");
 }

--- a/src/tryte.rs
+++ b/src/tryte.rs
@@ -7,6 +7,7 @@ use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use core::fmt::{Display, Formatter};
 use core::ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Neg as StdNeg, Not, Sub};
+use core::str::FromStr;
 use crate::concepts::DigitOperate;
 
 /// The `Tryte<S>` struct represents a Copy type balanced ternary number with exactly S digits (6 by default).
@@ -312,7 +313,7 @@ impl<const SIZE: usize> From<Tryte<SIZE>> for i64 {
     }
 }
 
-impl<const SIZE: usize> core::str::FromStr for Tryte<SIZE> {
+impl<const SIZE: usize> FromStr for Tryte<SIZE> {
     type Err = core::convert::Infallible;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {


### PR DESCRIPTION
## Summary
- implement `FromStr` for `Ternary` and `Tryte`
- re-export `FromStr` from crate root
- document parsing via `"+-0".parse::<Ternary>()`
- extend README with new example
- add tests using `FromStr`

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6846eb29907c832faf49bdf2233b5661