### PR TITLE
Add Ord implementation for Ternary

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -825,3 +825,22 @@ fn test_ordering() {
     assert!(ter("-+") < ter("0"));
     assert!(ter("0") < ter("++"));
 }
+
+#[cfg(test)]
+#[cfg(feature = "ternary-string")]
+#[test]
+fn test_ordering_additional() {
+    use crate::ter;
+
+    // Validate comparisons across a range of values
+    assert!(ter("--") < ter("-0"));
+    assert!(ter("-0") < ter("-"));
+    assert!(ter("+") < ter("+-"));
+    assert!(ter("+-") < ter("++"));
+
+    // Sorting should arrange values by their decimal value
+    let mut values = vec![ter("+"), ter("--"), ter("+-"), ter("-"), ter("0"), ter("-0"), ter("++")];
+    values.sort();
+    let expected = vec![ter("--"), ter("-0"), ter("-"), ter("0"), ter("+"), ter("+-"), ter("++")];
+    assert_eq!(values, expected);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@ use core::{
     fmt::{Display, Formatter},
     str::FromStr,
     error::Error,
+    cmp::Ordering,
 };
 
 #[cfg(feature = "ternary-string")]
@@ -642,6 +643,20 @@ impl FromStr for Ternary {
 }
 
 #[cfg(feature = "ternary-string")]
+impl Ord for Ternary {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.to_dec().cmp(&other.to_dec())
+    }
+}
+
+#[cfg(feature = "ternary-string")]
+impl PartialOrd for Ternary {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[cfg(feature = "ternary-string")]
 mod operations;
 
 mod conversions;
@@ -799,4 +814,14 @@ fn test_from_str() {
         assert_eq!(tryte.to_string(), "000+-0");
         assert!(<crate::Tryte>::from_str("+-x").is_err());
     }
+}
+
+#[cfg(test)]
+#[cfg(feature = "ternary-string")]
+#[test]
+fn test_ordering() {
+    use crate::ter;
+
+    assert!(ter("-+") < ter("0"));
+    assert!(ter("0") < ter("++"));
 }


### PR DESCRIPTION
## Summary
- implement `Ord` and `PartialOrd` for `Ternary`
- test ordering on simple ternary values

## Testing
- `cargo build`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6846fd852548832f8c554fb79ae89919