### PR TITLE
Add iteration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,24 @@ fn test() {
 }
 ```
 
+### Iterate through digits
+
+```rust
+use balanced_ternary::*;
+
+fn test() {
+    let ternary = Ternary::parse("+0-");
+
+    // Using `.iter()`
+    let v: Vec<Digit> = ternary.iter().cloned().collect();
+    assert_eq!(v, vec![Pos, Zero, Neg]);
+
+    // Using `IntoIterator`
+    let v: Vec<Digit> = Ternary::parse("+0-").into_iter().collect();
+    assert_eq!(v, vec![Pos, Zero, Neg]);
+}
+```
+
 ## Documentation
 
 The complete API documentation can be found [on docs.rs](https://docs.rs/balanced-ternary).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,6 +266,11 @@ impl Ternary {
         self.digits.as_slice()
     }
 
+    /// Returns an iterator over the digits from most significant to least significant.
+    pub fn iter(&self) -> core::slice::Iter<'_, Digit> {
+        self.digits.iter()
+    }
+
     /// Returns a reference to the [Digit] indexed by `index` if it exists.
     ///
     /// Digits are indexed **from the right**:
@@ -657,6 +662,16 @@ impl PartialOrd for Ternary {
 }
 
 #[cfg(feature = "ternary-string")]
+impl IntoIterator for Ternary {
+    type Item = Digit;
+    type IntoIter = alloc::vec::IntoIter<Digit>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.digits.into_iter()
+    }
+}
+
+#[cfg(feature = "ternary-string")]
 mod operations;
 
 mod conversions;
@@ -843,4 +858,17 @@ fn test_ordering_additional() {
     values.sort();
     let expected = vec![ter("--"), ter("-0"), ter("-"), ter("0"), ter("+"), ter("+-"), ter("++")];
     assert_eq!(values, expected);
+}
+
+#[cfg(test)]
+#[cfg(feature = "ternary-string")]
+#[test]
+fn test_iterators() {
+    use crate::*;
+
+    let ternary = Ternary::parse("+0-");
+    let expected = vec![Pos, Zero, Neg];
+    assert_eq!(ternary.iter().cloned().collect::<Vec<_>>(), expected);
+    let collected: Vec<Digit> = Ternary::parse("+0-").into_iter().collect();
+    assert_eq!(collected, expected);
 }


### PR DESCRIPTION
## Summary
- implement `iter` method on `Ternary`
- implement `IntoIterator` for `Ternary`
- document new iteration capabilities in the README
- add tests covering the new iterator

## Testing
- `cargo build`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68470dc1c56c832f8afb5c44484a1d11