### PR TITLE
Implement shift ops for Ternary

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ processing, and three-valued logic modeling.
 
 - **No Standard Library:** Suitable for `#![no_std]` environments.
 - **Number Conversions:** Convert between decimal and balanced ternary representations.
-- **Arithmetic Operations:** Support for addition, subtraction, multiplication, and division.
+- **Arithmetic Operations:** Support for addition, subtraction, multiplication, division, and bit shifting (`<<`, `>>`).
 - **[Three-value Logic Operations](https://en.wikipedia.org/wiki/Three-valued_logic):**
     - Support for bitwise and, or, xor, and not (in Kleene algebra (K3)).
     - **Advanced logic**: Implementation of
@@ -155,6 +155,11 @@ fn test() {
 
     let bitwise = &Ternary::parse("+000") | &Ternary::parse("000+");
     assert_eq!(bitwise.to_string(), "+00+");
+
+    let shifted = &Ternary::parse("+0-") << 2;
+    assert_eq!(shifted.to_string(), "+0-00");
+    let back = &shifted >> 2;
+    assert_eq!(back.to_string(), "+0-");
 }
 ```
 

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -31,7 +31,7 @@
 use crate::concepts::DigitOperate;
 use crate::{Digit, Ternary};
 use alloc::vec;
-use core::ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Neg, Not, Sub};
+use core::ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Neg, Not, Sub, Shl, Shr};
 
 impl Neg for &Ternary {
     type Output = Ternary;
@@ -143,6 +143,33 @@ impl BitXor<&Ternary> for &Ternary {
     }
 }
 
+impl Shl<usize> for &Ternary {
+    type Output = Ternary;
+
+    fn shl(self, rhs: usize) -> Self::Output {
+        let mut repr = Ternary::new(vec![]);
+        repr.digits.extend(self.digits.iter().cloned());
+        repr.digits.extend(core::iter::repeat(Digit::Zero).take(rhs));
+        repr
+    }
+}
+
+impl Shr<usize> for &Ternary {
+    type Output = Ternary;
+
+    fn shr(self, rhs: usize) -> Self::Output {
+        if rhs >= self.digits.len() {
+            return Ternary::parse("0");
+        }
+        let len = self.digits.len() - rhs;
+        let mut repr = Ternary::new(self.digits[..len].to_vec());
+        if repr.digits.is_empty() {
+            repr.digits.push(Digit::Zero);
+        }
+        repr
+    }
+}
+
 impl Not for &Ternary {
     type Output = Ternary;
     fn not(self) -> Self::Output {
@@ -191,4 +218,16 @@ fn test_ternary_ops() {
 
     let bitwise = &Ternary::parse("+000") | &Ternary::parse("000+");
     assert_eq!(bitwise.to_string(), "+00+");
+}
+
+#[cfg(test)]
+#[test]
+fn test_shift_ops() {
+    use alloc::string::ToString;
+    let t = Ternary::parse("+0-");
+    assert_eq!((&t << 2).to_string(), "+0-00");
+    let back = &(&t << 2) >> 2;
+    assert_eq!(back.to_string(), "+0-");
+    let zero = &t >> 5;
+    assert_eq!(zero.to_string(), "0");
 }


### PR DESCRIPTION
## Summary
- support `<<` and `>>` operators on `Ternary`
- test new shift behaviour
- document shifting in README

## Testing
- `cargo build`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6847113c38a0832fa5be8a86a07951bc